### PR TITLE
Husky v9+에 맞는 훅 처리로 수정

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no-install lint-staged


### PR DESCRIPTION
## 관련 이슈 번호
Resolves  #1 

## 주요 변경 내역
- husky v9+ 버전에 맞도록 `.husky/pre-commit`와 `.husky/commit.msg` 수정

- 기존의 shebang과 husky.sh 스크립트 로딩이 더 이상 필요하지 않아 제거

```
Please remove the following two lines from .husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```
## 참고
[husky](https://typicode.github.io/husky/)