### PR TITLE
펫페어 목록 페이지 및 검색 결과 페이지 구현

### DIFF
--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { SearchBar } from '@/components/search/search-bar';
+
+export default function WithSearchbarLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-background min-h-screen">
+      {/* 헤더 영역 */}
+      <div className="bg-background/95 supports-[backdrop-filter]:bg-background/60 border-border/40 sticky top-0 z-40 border-b backdrop-blur">
+        <div className="sticky container mx-auto max-w-md px-4 py-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-foreground text-xl font-bold">펫페어 🐾</h1>
+          </div>
+          <SearchBar />
+        </div>
+      </div>
+
+      <div className="container mx-auto max-w-md pb-20">
+        <div className="py-2">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-searchbar)/list/page.tsx
+++ b/src/app/(with-searchbar)/list/page.tsx
@@ -1,0 +1,44 @@
+import { EventCard } from '@/components/events/event-card';
+import { NoEvents } from '@/components/events/no-events';
+import { fetchCalendarEvents } from '@/lib/api/mock-calendar';
+
+export default async function EventListPage() {
+  const events = await fetchCalendarEvents();
+
+  return (
+    <div className="space-y-2">
+      {/* 목록 정보 */}
+      <div className="space-y-2 px-4">
+        <h2 className="text-foreground text-lg font-semibold">모든 펫페어</h2>
+        <p className="text-muted-foreground text-sm">
+          총 {events.length}개의 이벤트가 있습니다
+        </p>
+      </div>
+
+      {/* TODO: 필터 옵션 (향후 확장 예정) */}
+      <div className="- flex gap-2 overflow-x-auto px-2 pb-2">
+        <button className="bg-primary text-primary-foreground shrink-0 rounded-full px-4 py-2 text-sm font-medium">
+          전체
+        </button>
+        <button className="bg-muted text-muted-foreground hover:bg-muted/80 shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors">
+          진행중
+        </button>
+        <button className="bg-muted text-muted-foreground hover:bg-muted/80 shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors">
+          예정
+        </button>
+        <button className="bg-muted text-muted-foreground hover:bg-muted/80 shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors">
+          종료
+        </button>
+      </div>
+
+      {/* 이벤트 리스트 */}
+      <div className="space-y-3">
+        {events.length > 0 ? (
+          events.map((event) => <EventCard key={event.id} event={event} />)
+        ) : (
+          <NoEvents />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -1,0 +1,49 @@
+import { EventCard } from '@/components/events/event-card';
+import { NoSearchResult } from '@/components/search/no-search-result';
+import { fetchCalendarEvents } from '@/lib/api/mock-calendar';
+
+interface SearchPageProps {
+  searchParams: Promise<{ q?: string }>;
+}
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const params = await searchParams;
+  const q = params.q?.toLowerCase() || '';
+
+  const events = await fetchCalendarEvents();
+
+  const filtered = events.filter((event) =>
+    event.title.toLowerCase().includes(q)
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* 검색 결과 정보 */}
+      <div className="space-y-2 px-4">
+        <h2 className="text-foreground text-lg font-semibold">검색 결과</h2>
+        {q && (
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">검색어:</span>
+            <span className="bg-primary/10 text-primary rounded-full px-3 py-1 text-sm font-medium">
+              "{params.q}"
+            </span>
+          </div>
+        )}
+        <p className="text-muted-foreground text-sm">
+          {filtered.length > 0
+            ? `${filtered.length}개의 결과를 찾았습니다`
+            : '검색 결과가 없습니다'}
+        </p>
+      </div>
+
+      {/* 검색 결과 */}
+      <div className="space-y-4">
+        {filtered.length > 0 ? (
+          filtered.map((event) => <EventCard key={event.id} event={event} />)
+        ) : (
+          <NoSearchResult />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/event-card.tsx
+++ b/src/components/events/event-card.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { Calendar, MapPin } from 'lucide-react';
+
+import { CalendarEvent } from '@/lib/api/mock-calendar';
+
+interface Props {
+  event: CalendarEvent;
+}
+
+export function EventCard({ event }: Props) {
+  const startDate = format(event.from, 'M월 d일 (E)', { locale: ko });
+  const endDate = format(event.to, 'M월 d일 (E)', { locale: ko });
+  // const startTime = format(event.from, 'HH:mm');
+  // const endTime = format(event.to, 'HH:mm');
+  const eventLocation = '엑스포';
+
+  // 같은 날인지 확인
+  const isSameDay =
+    format(event.from, 'yyyy-MM-dd') === format(event.to, 'yyyy-MM-dd');
+
+  return (
+    <div className="group bg-card hover:bg-accent/50 active:bg-accent/70 border-border/50 hover:border-border rounded-xl border p-4 shadow-sm transition-all duration-200 hover:shadow-md">
+      {/* 헤더 */}
+      <div className="mb-3">
+        <h2 className="text-foreground group-hover:text-accent-foreground mb-1 text-base leading-tight font-semibold">
+          {event.title}
+        </h2>
+
+        {/* 상태 배지 (예: 진행중/예정/종료) */}
+        <div className="flex items-center gap-2">
+          <span className="bg-primary/10 text-primary rounded-full px-2 py-1 text-xs font-medium">
+            {new Date() < event.from
+              ? '예정'
+              : new Date() > event.to
+                ? '종료'
+                : '진행중'}
+          </span>
+        </div>
+      </div>
+
+      {/* 날짜 및 시간 정보 */}
+      <div className="space-y-2">
+        <div className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Calendar className="h-4 w-4 shrink-0" />
+          <span className="flex-1">
+            {isSameDay ? (
+              <span>{startDate}</span>
+            ) : (
+              <span>
+                {startDate} ~ {endDate}
+              </span>
+            )}
+          </span>
+        </div>
+
+        {/* 시간 정보 (추후 추가될 수 있는 필드) */}
+        {/* <div className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Clock className="h-4 w-4 shrink-0" />
+          <span className="flex-1">
+            {startTime} ~ {endTime}
+          </span>
+        </div> */}
+
+        <div className="text-muted-foreground flex items-center gap-2 text-sm">
+          <MapPin className="h-4 w-4 shrink-0" />
+          <span className="flex-1">{eventLocation}</span>
+        </div>
+      </div>
+
+      {/* 액션 영역 */}
+      <div className="border-border/30 mt-4 border-t pt-3">
+        <div className="flex items-center justify-between">
+          <div className="text-muted-foreground flex items-center gap-1 text-xs">
+            <div className="h-2 w-2 rounded-full bg-green-500"></div>
+            <span>참가 가능</span>
+          </div>
+
+          <button className="text-primary hover:text-primary/80 text-sm font-medium transition-colors hover:underline">
+            자세히 보기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/no-events.tsx
+++ b/src/components/events/no-events.tsx
@@ -1,0 +1,17 @@
+export function NoEvents() {
+  return (
+    <div className="py-12 text-center">
+      <div className="mb-4">
+        <div className="bg-muted mx-auto flex h-16 w-16 items-center justify-center rounded-full">
+          <span className="text-2xl">🐾</span>
+        </div>
+      </div>
+      <h3 className="text-foreground mb-2 text-lg font-medium">
+        아직 이벤트가 없어요
+      </h3>
+      <p className="text-muted-foreground text-sm">
+        새로운 펫페어가 곧 추가될 예정입니다
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/bottom-navigation.tsx
+++ b/src/components/layout/bottom-navigation.tsx
@@ -11,7 +11,6 @@ interface NavItem {
   href: string;
   icon: React.ElementType;
   label: string;
-  isSpecial?: boolean; // 특별한 스타일링을 위한 플래그 (예: 플러스 버튼)
 }
 
 interface BottomNavigationProps {
@@ -54,8 +53,7 @@ export function BottomNavigation({
                 'min-h-[60px] rounded-lg', // 터치 영역 확보
                 isActive
                   ? 'text-primary'
-                  : 'text-muted-foreground hover:text-foreground',
-                item.isSpecial && 'relative' // 특별한 아이템을 위한 클래스
+                  : 'text-muted-foreground hover:text-foreground'
               )}
             >
               <div
@@ -77,11 +75,6 @@ export function BottomNavigation({
               >
                 {item.label}
               </span>
-
-              {/* 활성 상태 인디케이터 */}
-              {isActive && !item.isSpecial && (
-                <div className="bg-primary absolute bottom-0 h-0.5 w-6 rounded-full" />
-              )}
             </Link>
           );
         })}

--- a/src/components/search/no-search-result.tsx
+++ b/src/components/search/no-search-result.tsx
@@ -1,0 +1,38 @@
+export function NoSearchResult() {
+  return (
+    <div className="py-12 text-center">
+      <div className="mb-4">
+        <div className="bg-muted mx-auto flex h-16 w-16 items-center justify-center rounded-full">
+          <span className="text-2xl">🔍</span>
+        </div>
+      </div>
+      <h3 className="text-foreground mb-2 text-lg font-medium">
+        검색 결과가 없어요
+      </h3>
+      <p className="text-muted-foreground mb-4 text-sm">
+        다른 키워드로 검색해보시거나
+        <br />
+        전체 이벤트 목록을 확인해보세요
+      </p>
+
+      {/* 추천 검색어(향후 확장 예정) */}
+      <div className="space-y-3">
+        <p className="text-muted-foreground text-xs">추천 검색어</p>
+        <div className="flex flex-wrap justify-center gap-2">
+          <button className="bg-muted hover:bg-muted/80 text-muted-foreground rounded-full px-3 py-1 text-sm transition-colors">
+            강아지
+          </button>
+          <button className="bg-muted hover:bg-muted/80 text-muted-foreground rounded-full px-3 py-1 text-sm transition-colors">
+            고양이
+          </button>
+          <button className="bg-muted hover:bg-muted/80 text-muted-foreground rounded-full px-3 py-1 text-sm transition-colors">
+            훈련
+          </button>
+          <button className="bg-muted hover:bg-muted/80 text-muted-foreground rounded-full px-3 py-1 text-sm transition-colors">
+            건강
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/search/recent-search.tsx
+++ b/src/components/search/recent-search.tsx
@@ -1,0 +1,15 @@
+export function RecentSearch() {
+  return (
+    <div className="bg-background border-border absolute top-full right-0 left-0 z-50 mt-2 rounded-xl border p-3 shadow-lg">
+      <div className="text-muted-foreground mb-2 text-xs">최근 검색어</div>
+      <div className="space-y-1">
+        <button className="hover:bg-muted w-full rounded-lg px-3 py-2 text-left text-sm transition-colors">
+          강아지
+        </button>
+        <button className="hover:bg-muted w-full rounded-lg px-3 py-2 text-left text-sm transition-colors">
+          고양이
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/search/search-bar.tsx
+++ b/src/components/search/search-bar.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Loader2, Search } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
+
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+
+import { RecentSearch } from './recent-search';
+
+export function SearchBar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [search, setSearch] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+
+  const currentQuery = useMemo(
+    () => searchParams.get('q') || '',
+    [searchParams]
+  );
+
+  useEffect(() => {
+    setSearch(currentQuery);
+  }, [currentQuery]);
+
+  const executeSearch = useCallback(
+    (query: string) => {
+      const trimmedQuery = query.trim();
+
+      if (!trimmedQuery) {
+        startTransition(() => {
+          router.push('/list');
+        });
+        return;
+      }
+
+      if (currentQuery === trimmedQuery) return;
+
+      startTransition(() => {
+        router.push(`/search?q=${encodeURIComponent(trimmedQuery)}`);
+      });
+    },
+    [router, currentQuery]
+  );
+
+  const handleSubmit = useCallback(
+    (e?: React.FormEvent) => {
+      e?.preventDefault();
+      executeSearch(search);
+    },
+    [search, executeSearch]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleSubmit();
+      }
+      if (e.key === 'Escape') {
+        setSearch('');
+        setIsFocused(false);
+      }
+    },
+    [handleSubmit]
+  );
+
+  return (
+    <div className="w-full">
+      <form onSubmit={handleSubmit} className="relative" role="search">
+        <div
+          className={`bg-background relative flex items-center rounded-xl border shadow-sm transition-all duration-200 ${
+            isFocused
+              ? 'border-primary ring-primary/20 shadow-lg ring-2'
+              : 'border-border hover:border-border/80'
+          } ${isPending ? 'opacity-75' : ''} `}
+        >
+          <div className="pr-2 pl-4">
+            {isPending ? (
+              <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+            ) : (
+              <Search className="text-muted-foreground h-5 w-5" />
+            )}
+          </div>
+
+          <Input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder="펫페어를 검색해보세요"
+            className="placeholder:text-muted-foreground flex-1 bg-transparent py-3 pr-4 text-sm focus:outline-none disabled:cursor-not-allowed"
+            disabled={isPending}
+            aria-label="검색어 입력"
+            autoComplete="off"
+          />
+
+          <Button
+            type="submit"
+            disabled={isPending || !search.trim()}
+            className="bg-primary hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground text-primary-foreground mr-2 rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-200 disabled:cursor-not-allowed"
+            aria-label="검색 실행"
+          >
+            {isPending ? '검색중' : '검색'}
+          </Button>
+        </div>
+
+        {/* 최근 검색어 (향후 확장 가능) */}
+        {isFocused && !search && <RecentSearch />}
+      </form>
+    </div>
+  );
+}

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };


### PR DESCRIPTION
## 관련 이슈 번호

Resolves #12 

## 주요 변경 내용

- 펫페어의 목록과 검색 결과를 보여주는 페이지을 구현
- 두 페이지를 (with-searchbar)로 폴더링 후 `layout.tsx`를 통해`SearchBar` 공통 적용
  - `/(with-searchbar)/list/page.tsx`
  - `/(with-searchbar)/search/page.tsx`
- `EventCard`, `NoEvents`, `NoSearchResult`, `RecentSearch` 컴포넌트 추가
- shadcn/ui의 `Input` 컴포넌트 추가

## 이외 기타 변경 사항

- `bottom-navigation.tsx`  리펙토링

## PR 시 참고 사항

- MVP 단계에 맞춰 제작한 페이지입니다.
- 기능 추가에 따라 추후 변경이 있을 예정입니다.
- 개발 모드 실행으로 확인할 때 개발자 도구에서 기기 툴바 전환을 해주세요. (ctrl+shift+m)
- /list 나 하단 내비게이션의 목록 버튼을 클릭하면 확인할 수 있습니다.
- 검색 결과 페이지는 /list(목록 페이지) 에서 검색 후 확인 가능합니다.

