### PR TITLE
캐러셀 자동재생 딜레이 및 네비게이션 버튼 스타일 개선

### DIFF
--- a/src/components/main/carousel-container.tsx
+++ b/src/components/main/carousel-container.tsx
@@ -24,7 +24,7 @@ export function CarouselContainer({ carouselData }: CarouselContainerProps) {
           loop: true,
           align: 'start',
         }}
-        delay={2000}
+        delay={4000}
       >
         <CarouselContent className="items-start">
           {carouselData.map((item, index) => (
@@ -44,8 +44,8 @@ export function CarouselContainer({ carouselData }: CarouselContainerProps) {
           <CarouselAutoplayButton />
           <SlidePagination />
         </div>
-        <CarouselPrevious className="left-2" />
-        <CarouselNext className="right-2" />
+        <CarouselPrevious className="-left-0.5 size-12" />
+        <CarouselNext className="-right-0.5 size-12" />
       </Carousel>
     </div>
   );


### PR DESCRIPTION
## 관련 이슈 번호

Resolves #22 

## 핵심 변경 사항 및 이유
기존의 캐러셀에 대한 팀원들의 피드백 사항을 반영하여 아래와 같이 변경함
- 자동재생 딜레이를 2초에서 4초로 늘려 사용자 가독성 향상
- 이전/다음 버튼 위치를 조정하고 크기를 12로 증가시켜 접근성 개선

## 관련 이미지
너비가 1024px일 때의 이미지 캡처 
<img width="1181" height="800" alt="image" src="https://github.com/user-attachments/assets/6a159d6e-e769-4df7-9207-cac64a26a6a5" />


